### PR TITLE
Fix for BusinessActivity complete method

### DIFF
--- a/bpel-runtime/src/main/java/org/apache/ode/bpel/engine/BpelRuntimeContextImpl.java
+++ b/bpel-runtime/src/main/java/org/apache/ode/bpel/engine/BpelRuntimeContextImpl.java
@@ -1130,7 +1130,7 @@ public class BpelRuntimeContextImpl implements BpelRuntimeContext {
                 try {
                     _wst.complete();
                 } catch (Exception e) {
-                    __log.warn("BusinessActivity partially completion failed.", e);
+                    __log.warn("BusinessActivity partial completion failed.", e);
                 }
             }
             

--- a/bpel-runtime/src/main/java/org/apache/ode/bpel/wstx/BusinessActivity.java
+++ b/bpel-runtime/src/main/java/org/apache/ode/bpel/wstx/BusinessActivity.java
@@ -107,7 +107,12 @@ public class BusinessActivity implements WebServiceTransaction {
     }
     
     public void complete() throws UnknownTransactionException, SystemException, WrongStateException {
-        _uba.complete();
+        try {
+            resume();
+            _uba.complete();
+        } catch (WrongStateException ex) {
+            __log.warn("Business Activity Transaction WrongStateException for completion.");
+        }
     }
 
     public boolean isActive() {


### PR DESCRIPTION
Sometimes a partial complete of transaction simply cannot be done but it is not important because it can be done later or it is finished by close then, so for that reason I catch the WrongStateException.

And to be sure that the complete method works with the appropriate transaction I check it by resume method. 
