### PR TITLE
Added explicit dependency on xercesImpl

### DIFF
--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -33,6 +33,10 @@
 
   <dependencies>
     <dependency>
+    	<groupId>xerces</groupId>
+    	<artifactId>xercesImpl</artifactId>
+    </dependency>
+    <dependency>
         <groupId>org.apache.ws.commons.axiom</groupId>
         <artifactId>axiom-api</artifactId>
     </dependency>


### PR DESCRIPTION
The DOMUtils class uses classes from xerces so it is sensible to have a direct dependency on xercesImpl rather than getting a random version from a transitive dependency.
